### PR TITLE
Print help message when command is missing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,11 @@ from tree_printer import TreePrinter
 from util import *
 
 
-def main(args):
+def main():
+    argparser = parser.getParser()
+    args = argparser.parse_known_args()
+    args = argparser.parse_args(args[1], args[0])
+
     command = args.command
 
     if command != "continue" and (
@@ -256,7 +260,7 @@ def main(args):
         TreePrinter.print(tree["head"])
 
     else:
-        return "Unknown gum command"
+        argparser.print_help()
 
 
 def updateHead():
@@ -284,6 +288,6 @@ def updateHead():
 
 
 if __name__ == '__main__':
-    result = main(parser.getArgs())
+    result = main()
     if result is not None:
         print(result)

--- a/src/parser.py
+++ b/src/parser.py
@@ -15,7 +15,7 @@
 import argparse
 
 
-def getArgs():
+def getParser():
     parser = argparse.ArgumentParser(
         prog="gm", description="Gum: A Mercurial Style Git Wrapper.")
     subparsers = parser.add_subparsers(dest="command")
@@ -134,6 +134,4 @@ def getArgs():
         action="store_true",
         help="Display the Git commands but don't actually run them.")
 
-    args = parser.parse_known_args()
-    args = parser.parse_args(args[1], args[0])
-    return args
+    return parser


### PR DESCRIPTION
Use the argparser to print the usage if no subcommand is specified.
